### PR TITLE
Don't set the locale environment for Elixir/BEAM in the devShell

### DIFF
--- a/elixir-phoenix/flake.nix
+++ b/elixir-phoenix/flake.nix
@@ -72,7 +72,6 @@
 
         inherit (self.checks.${pkgs.system}.pre-commit-check) shellHook;
 
-        LANG = "C.UTF-8";
         ERL_AFLAGS = "-kernel shell_history enabled";
       };
     });


### PR DESCRIPTION
Even though the Erlang VM assumes UTF-8 locale settings on the host environment, developers want different locale settings depending on their own needs. Thus the locale should not be set in the devShell.