### PR TITLE
Use the default channel of nixpkgs-unstable in all templates

### DIFF
--- a/dev/flake.nix
+++ b/dev/flake.nix
@@ -1,6 +1,6 @@
 {
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    # nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     systems.url = "github:nix-systems/default";
     pre-commit-hooks.url = "github:cachix/pre-commit-hooks.nix";
     # To be overridden during execution

--- a/elixir-phoenix/flake.nix
+++ b/elixir-phoenix/flake.nix
@@ -1,5 +1,6 @@
 {
   inputs = {
+    # nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     pre-commit-hooks = {
       url = "github:cachix/pre-commit-hooks.nix";
       inputs.nixpkgs.follows = "nixpkgs";

--- a/elixir/flake.nix
+++ b/elixir/flake.nix
@@ -1,5 +1,6 @@
 {
   inputs = {
+    # nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     systems.url = "github:nix-systems/default";
   };
 

--- a/flake-utils/flake.nix
+++ b/flake-utils/flake.nix
@@ -1,5 +1,8 @@
 {
-  inputs.systems.url = "github:nix-systems/default";
+  inputs = {
+    # nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    systems.url = "github:nix-systems/default";
+  };
 
   outputs = {
     self,

--- a/minimal/flake.nix
+++ b/minimal/flake.nix
@@ -1,6 +1,6 @@
 {
   inputs = {
-    # nixpkgs.url = "github:NixOS/nixpkgs/master";
+    # nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     systems.url = "github:nix-systems/default";
   };
 

--- a/node-typescript/flake.nix
+++ b/node-typescript/flake.nix
@@ -1,7 +1,6 @@
 {
   inputs = {
-    # You can override nixpkgs to use the latest set of node packages
-    # nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    # nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     systems.url = "github:nix-systems/default";
   };
 

--- a/pre-commit/flake.nix
+++ b/pre-commit/flake.nix
@@ -1,10 +1,13 @@
 {
-  inputs.pre-commit-hooks = {
-    url = "github:cachix/pre-commit-hooks.nix";
-    inputs.nixpkgs.follows = "nixpkgs";
-    inputs.flake-utils.follows = "flake-utils";
+  inputs = {
+    # nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    pre-commit-hooks = {
+      url = "github:cachix/pre-commit-hooks.nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.flake-utils.follows = "flake-utils";
+    };
+    systems.url = "github:nix-systems/default";
   };
-  inputs.systems.url = "github:nix-systems/default";
 
   outputs = {
     self,

--- a/pulumi-ts/flake.nix
+++ b/pulumi-ts/flake.nix
@@ -1,5 +1,8 @@
 {
-  inputs.systems.url = "github:nix-systems/default";
+  inputs = {
+    # nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    systems.url = "github:nix-systems/default";
+  };
 
   outputs = {
     self,

--- a/rust/flake.nix
+++ b/rust/flake.nix
@@ -1,5 +1,6 @@
 {
   inputs = {
+    # nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     rust-overlay.url = "github:oxalica/rust-overlay";
     systems.url = "github:nix-systems/default";
     treefmt-nix = {

--- a/treefmt/flake.nix
+++ b/treefmt/flake.nix
@@ -1,5 +1,6 @@
 {
   inputs = {
+    # nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     systems.url = "github:nix-systems/default";
     treefmt-nix = {
       url = "github:numtide/treefmt-nix";


### PR DESCRIPTION
A cross-platform development environment should prefer `nixpkgs-*` over `nixos-*`, which is pointed to by `nixpkgs` entry in the global registry. There is no need to set the input explicitly.