### PR TITLE
Add repository_dispatch trigger to run all check workflows

### DIFF
--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -2,6 +2,9 @@ name: Run all check workflows
 
 on:
   workflow_dispatch:
+  repository_dispatch:
+    types:
+    - check
 
 jobs:
   check-elixir-phoenix:


### PR DESCRIPTION
Following up to #78, this allows workflow dispatch via https://github.com/peter-evans/repository-dispatch.