### PR TITLE
Use the second last major version of BEAM from nixpkgs

### DIFF
--- a/dev/update-beam.nix
+++ b/dev/update-beam.nix
@@ -18,7 +18,7 @@ to their latest versions. It performs simple regexp substitutions in flake.nix.
         inherit (value) version;
       }))
       (sort (a: b: compareVersions a.version b.version > 0))
-      head
+      (elems: builtins.elemAt elems 1)
       (x: x.name)
     ];
 


### PR DESCRIPTION
This is intended to avoid cache miss and other build failures. The latest release seems to be sometimes unstable.