### PR TITLE
Add platform-specific file watchers to the Gleam template

### DIFF
--- a/gleam/flake.nix
+++ b/gleam/flake.nix
@@ -23,11 +23,18 @@
 
     devShells = eachSystem (pkgs: {
       default = pkgs.mkShell {
-        buildInputs = [
-          pkgs.gleam
-          pkgs.beam.interpreters.${erlang_version}
-          pkgs.beam.packages.${erlang_version}.rebar3
-        ];
+        buildInputs = with pkgs; ([
+            gleam
+            beam.interpreters.${erlang_version}
+            beam.packages.${erlang_version}.rebar3
+          ]
+          ++ lib.optional stdenv.isLinux inotify-tools
+          ++ (
+            lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [
+              CoreFoundation
+              CoreServices
+            ])
+          ));
       };
     });
   };


### PR DESCRIPTION
These are recommended options for a framework like [Lustre](https://hexdocs.pm/lustre/).