### PR TITLE
Prefer systems.flakeExposed from nixpkgs 

### DIFF
--- a/doc/astro.config.mjs
+++ b/doc/astro.config.mjs
@@ -111,6 +111,10 @@ export default defineConfig({
                 },
               ],
             },
+            {
+              label: "Using nix-systems",
+              slug: "patterns/nix-systems",
+            },
           ],
         },
         {

--- a/doc/src/content/docs/patterns/nix-systems.mdoc
+++ b/doc/src/content/docs/patterns/nix-systems.mdoc
@@ -1,0 +1,46 @@
+---
+# SPDX-FileCopyrightText: 2025 Akira Komamura
+# SPDX-License-Identifier: CC-BY-SA-4.0
+title: Using nix-systems
+---
+
+For some reasons, you might want to limit the target systems of your flake.
+Most templates use `lib.systems.flakeExposed` from nixpkgs to specify the target
+systems, but your Nix packages may not be supported on some of the systems.
+It would be possible to explicitly list the target systems in your flake, but
+that can be a restriction to its consumers.
+
+With [nix-systems](https://github.com/nix-systems/nix-systems), you can specify
+the default target systems, while allowing users to override the setting at
+their discretion.
+
+To use nix-systems, follow these steps:
+
+{% steps %}
+
+1. Add `systems` input to your flake.nix:
+
+   ```nix
+     inputs = {
+       ...
+   +   systems.url = "github:nix-systems/default";
+     };
+   ```
+
+2. Make `systems` input visible in the `outputs` scope in the flake.nix:
+
+   ```diff lang="nix" title="flake.nix"
+   - outputs = { nixpkgs, ... }:
+   + outputs = { nixpkgs, systems, ... }:
+   ```
+
+3. Replace `nixpkgs.lib.systems.flakeExposed` with `(import systems)`:
+
+   ```diff lang="nix" title="flake.nix"
+      eachSystem =
+        f:
+   -    nixpkgs.lib.genAttrs nixpkgs.lib.systems.flakeExposed (system: f nixpkgs.legacyPackages.${system});
+   +    nixpkgs.lib.genAttrs (import systems) (system: f nixpkgs.legacyPackages.${system});
+   ```
+
+{% /steps %}

--- a/elixir-app/flake.nix
+++ b/elixir-app/flake.nix
@@ -3,7 +3,7 @@
 {
   inputs = {
     # nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
-    systems.url = "github:nix-systems/default";
+    # systems.url = "github:nix-systems/default";
     flake-parts.url = "github:hercules-ci/flake-parts";
     # Lexical is an alternative LSP server. There are several options for Elixir
     # LSP. See https://gist.github.com/Nezteb/dc63f1d5ad9d88907dd103da2ca000b1
@@ -16,7 +16,6 @@
     {
       self,
       nixpkgs,
-      systems,
       flake-parts,
       ...
     }@inputs:
@@ -27,7 +26,7 @@
       elixirVersion = "elixir_1_15";
     in
     flake-parts.lib.mkFlake { inherit inputs; } {
-      systems = import systems;
+      systems = nixpkgs.lib.systems.flakeExposed;
 
       imports = [ inputs.process-compose-flake.flakeModule ];
 

--- a/elixir/flake.nix
+++ b/elixir/flake.nix
@@ -3,11 +3,11 @@
 {
   inputs = {
     # nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
-    systems.url = "github:nix-systems/default";
+    # systems.url = "github:nix-systems/default";
   };
 
   outputs =
-    { nixpkgs, systems, ... }@inputs:
+    { nixpkgs, ... }@inputs:
     let
       inherit (nixpkgs) lib;
 
@@ -18,7 +18,7 @@
 
       eachSystem =
         f:
-        nixpkgs.lib.genAttrs (import systems) (
+        nixpkgs.lib.genAttrs nixpkgs.lib.systems.flakeExposed (
           system:
           f (
             import nixpkgs {

--- a/flake-utils/flake.nix
+++ b/flake-utils/flake.nix
@@ -3,7 +3,7 @@
 {
   inputs = {
     # nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
-    systems.url = "github:nix-systems/default";
+    # systems.url = "github:nix-systems/default";
   };
 
   outputs =
@@ -11,9 +11,8 @@
       self,
       nixpkgs,
       flake-utils,
-      systems,
     }:
-    flake-utils.lib.eachSystem (import systems) (
+    flake-utils.lib.eachSystem nixpkgs.lib.systems.flakeExposed (
       system:
       let
         pkgs = import nixpkgs { inherit system; };

--- a/gleam/flake.nix
+++ b/gleam/flake.nix
@@ -3,13 +3,13 @@
 {
   inputs = {
     # nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
-    systems.url = "github:nix-systems/default";
+    # systems.url = "github:nix-systems/default";
   };
 
   outputs =
-    { systems, nixpkgs, ... }@inputs:
+    { nixpkgs, ... }@inputs:
     let
-      eachSystem = f: nixpkgs.lib.genAttrs (import systems) (system: f nixpkgs.legacyPackages.${system});
+      eachSystem = f: nixpkgs.lib.genAttrs nixpkgs.lib.systems.flakeExposed (system: f nixpkgs.legacyPackages.${system});
 
       erlang_version = "erlang_25";
     in

--- a/go/flake.nix
+++ b/go/flake.nix
@@ -3,7 +3,7 @@
 {
   inputs = {
     # nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
-    systems.url = "github:nix-systems/default";
+    # systems.url = "github:nix-systems/default";
     treefmt-nix = {
       url = "github:numtide/treefmt-nix";
       inputs.nixpkgs.follows = "nixpkgs";
@@ -23,14 +23,13 @@
   outputs =
     {
       self,
-      systems,
       nixpkgs,
       treefmt-nix,
       ...
     }:
     let
       inherit (nixpkgs) lib;
-      eachSystem = f: lib.genAttrs (import systems) (system: f nixpkgs.legacyPackages.${system});
+      eachSystem = f: lib.genAttrs nixpkgs.lib.systems.flakeExposed (system: f nixpkgs.legacyPackages.${system});
 
       treefmtEval = eachSystem (pkgs: treefmt-nix.lib.evalModule pkgs ./treefmt.nix);
     in

--- a/minimal/flake.nix
+++ b/minimal/flake.nix
@@ -3,13 +3,13 @@
 {
   inputs = {
     # nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
-    systems.url = "github:nix-systems/default";
+    # systems.url = "github:nix-systems/default";
   };
 
   outputs =
-    { systems, nixpkgs, ... }@inputs:
+    { nixpkgs, ... }@inputs:
     let
-      eachSystem = f: nixpkgs.lib.genAttrs (import systems) (system: f nixpkgs.legacyPackages.${system});
+      eachSystem = f: nixpkgs.lib.genAttrs nixpkgs.lib.systems.flakeExposed (system: f nixpkgs.legacyPackages.${system});
     in
     {
       packages = eachSystem (pkgs: {

--- a/ocaml/flake.nix
+++ b/ocaml/flake.nix
@@ -3,12 +3,11 @@
 {
   inputs = {
     nixpkgs.url = "github:nix-ocaml/nix-overlays";
-    systems.url = "github:nix-systems/default";
+    # systems.url = "github:nix-systems/default";
   };
 
   outputs =
     {
-      systems,
       nixpkgs,
       self,
       ...
@@ -16,7 +15,7 @@
     let
       eachSystem =
         f:
-        nixpkgs.lib.genAttrs (import systems) (
+        nixpkgs.lib.genAttrs nixpkgs.lib.systems.flakeExposed (
           system:
           f (
             nixpkgs.legacyPackages.${system}.extend (

--- a/pre-commit/flake.nix
+++ b/pre-commit/flake.nix
@@ -8,7 +8,7 @@
       inputs.nixpkgs.follows = "nixpkgs";
       inputs.flake-utils.follows = "flake-utils";
     };
-    systems.url = "github:nix-systems/default";
+    # systems.url = "github:nix-systems/default";
   };
 
   outputs =
@@ -16,10 +16,9 @@
       self,
       nixpkgs,
       flake-utils,
-      systems,
       pre-commit-hooks,
     }:
-    flake-utils.lib.eachSystem (import systems) (
+    flake-utils.lib.eachSystem nixpkgs.lib.systems.flakeExposed (
       system:
       let
         pkgs = import nixpkgs { inherit system; };

--- a/rust/flake.nix
+++ b/rust/flake.nix
@@ -4,7 +4,7 @@
   inputs = {
     flake-parts.url = "github:hercules-ci/flake-parts";
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
-    systems.url = "github:nix-systems/default";
+    # systems.url = "github:nix-systems/default";
 
     treefmt-nix.url = "github:numtide/treefmt-nix";
 
@@ -34,7 +34,7 @@
       rustProfile = "default";
     in
     flake-parts.lib.mkFlake { inherit inputs; } {
-      systems = import inputs.systems;
+      systems = nixpkgs.lib.systems.flakeExposed;
 
       imports = [
         inputs.treefmt-nix.flakeModule

--- a/treefmt/flake.nix
+++ b/treefmt/flake.nix
@@ -3,7 +3,7 @@
 {
   inputs = {
     # nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
-    systems.url = "github:nix-systems/default";
+    # systems.url = "github:nix-systems/default";
     treefmt-nix = {
       url = "github:numtide/treefmt-nix";
       inputs.nixpkgs.follows = "nixpkgs";
@@ -13,13 +13,12 @@
   outputs =
     {
       self,
-      systems,
       nixpkgs,
       treefmt-nix,
       ...
     }@inputs:
     let
-      eachSystem = f: nixpkgs.lib.genAttrs (import systems) (system: f nixpkgs.legacyPackages.${system});
+      eachSystem = f: nixpkgs.lib.genAttrs nixpkgs.lib.systems.flakeExposed (system: f nixpkgs.legacyPackages.${system});
 
       treefmtEval = eachSystem (pkgs: treefmt-nix.lib.evalModule pkgs ./treefmt.nix);
     in

--- a/zig/flake.nix
+++ b/zig/flake.nix
@@ -3,7 +3,7 @@
 {
   inputs = {
     # nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
-    systems.url = "github:nix-systems/default";
+    # systems.url = "github:nix-systems/default";
     treefmt-nix = {
       url = "github:numtide/treefmt-nix";
       inputs.nixpkgs.follows = "nixpkgs";
@@ -13,13 +13,12 @@
   outputs =
     {
       self,
-      systems,
       nixpkgs,
       treefmt-nix,
       ...
     }@inputs:
     let
-      eachSystem = f: nixpkgs.lib.genAttrs (import systems) (system: f nixpkgs.legacyPackages.${system});
+      eachSystem = f: nixpkgs.lib.genAttrs nixpkgs.lib.systems.flakeExposed (system: f nixpkgs.legacyPackages.${system});
 
       treefmtEval = eachSystem (pkgs: treefmt-nix.lib.evalModule pkgs ./treefmt.nix);
     in


### PR DESCRIPTION
Unless the user wishes to explicitly limit the target systems, `lib.systems.flakeExposed` from nixpkgs requires a slightly smaller number of flake inputs, and it covers a broader set of systems, which is good as NixOS expands. I will make it the default. 