### PR TITLE
Delete the SPDX copyright headers from unlicensed files

### DIFF
--- a/doc/src/content/docs/getting-started.mdoc
+++ b/doc/src/content/docs/getting-started.mdoc
@@ -30,12 +30,15 @@ new development environment from a flake template.
 
 {% aside type="note" %}
 Because `flake-templates` is a multi-licensed repository, each file in a
-template contains a header that describes its license. The following is an
-example:
+template contains a header that describes its license. See the examples below:
+
+```
+# SPDX-License-Identifier: Unlicense
+```
 
 ```
 # SPDX-FileCopyrightText: 2021-2025 Akira Komamura
-# SPDX-License-Identifier: Unlicense
+# SPDX-License-Identifier: MIT
 ```
 
 If the generated file is licensed under `Unlicense`, you can safely remove the

--- a/elixir-app/flake.nix
+++ b/elixir-app/flake.nix
@@ -1,4 +1,3 @@
-# SPDX-FileCopyrightText: 2021-2025 Akira Komamura
 # SPDX-License-Identifier: Unlicense
 {
   inputs = {

--- a/elixir/flake.nix
+++ b/elixir/flake.nix
@@ -1,4 +1,3 @@
-# SPDX-FileCopyrightText: 2021-2025 Akira Komamura
 # SPDX-License-Identifier: Unlicense
 {
   inputs = {

--- a/flake-parts/flake.nix
+++ b/flake-parts/flake.nix
@@ -1,4 +1,3 @@
-# SPDX-FileCopyrightText: 2025 Akira Komamura
 # SPDX-License-Identifier: Unlicense
 {
   inputs = {

--- a/flake-utils/flake.nix
+++ b/flake-utils/flake.nix
@@ -1,4 +1,3 @@
-# SPDX-FileCopyrightText: 2021-2025 Akira Komamura
 # SPDX-License-Identifier: Unlicense
 {
   inputs = {

--- a/gleam/flake.nix
+++ b/gleam/flake.nix
@@ -1,4 +1,3 @@
-# SPDX-FileCopyrightText: 2024-2025 Akira Komamura
 # SPDX-License-Identifier: Unlicense
 {
   inputs = {

--- a/go/flake.nix
+++ b/go/flake.nix
@@ -1,4 +1,3 @@
-# SPDX-FileCopyrightText: 2024 Akira Komamura
 # SPDX-License-Identifier: Unlicense
 {
   inputs = {

--- a/go/treefmt.nix
+++ b/go/treefmt.nix
@@ -1,4 +1,3 @@
-# SPDX-FileCopyrightText: 2024 Akira Komamura
 # SPDX-License-Identifier: Unlicense
 {
   projectRootFile = "treefmt.nix";

--- a/meta/.github/workflows/nix-build.yml
+++ b/meta/.github/workflows/nix-build.yml
@@ -1,4 +1,3 @@
-# SPDX-FileCopyrightText: 2024-2025 Akira Komamura
 # SPDX-License-Identifier: Unlicense
 name: Build the Nix package
 

--- a/meta/.github/workflows/nix-format.yml
+++ b/meta/.github/workflows/nix-format.yml
@@ -1,4 +1,3 @@
-# SPDX-FileCopyrightText: 2024-2025 Akira Komamura
 # SPDX-License-Identifier: Unlicense
 name: Check format
 

--- a/meta/.gitignore
+++ b/meta/.gitignore
@@ -1,4 +1,3 @@
-# SPDX-FileCopyrightText: 2024-2025 Akira Komamura
 # SPDX-License-Identifier: Unlicense
 result
 result-*

--- a/minimal/flake.nix
+++ b/minimal/flake.nix
@@ -1,4 +1,3 @@
-# SPDX-FileCopyrightText: 2021-2025 Akira Komamura
 # SPDX-License-Identifier: Unlicense
 {
   inputs = {

--- a/node-typescript/flake.nix
+++ b/node-typescript/flake.nix
@@ -1,4 +1,3 @@
-# SPDX-FileCopyrightText: 2021-2025 Akira Komamura
 # SPDX-License-Identifier: Unlicense
 {
   inputs = {

--- a/ocaml-dune/.gitignore
+++ b/ocaml-dune/.gitignore
@@ -1,3 +1,2 @@
-# SPDX-FileCopyrightText: 2024-2025 Akira Komamura
 # SPDX-License-Identifier: Unlicense
 _build

--- a/ocaml-dune/flake.nix
+++ b/ocaml-dune/flake.nix
@@ -1,4 +1,3 @@
-# SPDX-FileCopyrightText: 2024-2025 Akira Komamura
 # SPDX-License-Identifier: Unlicense
 {
   inputs = {

--- a/ocaml-dune/justfile
+++ b/ocaml-dune/justfile
@@ -1,4 +1,3 @@
-# SPDX-FileCopyrightText: 2024-2025 Akira Komamura
 # SPDX-License-Identifier: Unlicense
 
 # The default cache path is immutable when odig is installed using Nix

--- a/pre-commit/flake.nix
+++ b/pre-commit/flake.nix
@@ -1,4 +1,3 @@
-# SPDX-FileCopyrightText: 2021-2025 Akira Komamura
 # SPDX-License-Identifier: Unlicense
 {
   inputs = {

--- a/python-uv-simple/flake.nix
+++ b/python-uv-simple/flake.nix
@@ -1,4 +1,3 @@
-# SPDX-FileCopyrightText: 2025 Akira Komamura
 # SPDX-License-Identifier: Unlicense
 {
   inputs = {

--- a/rust/flake.nix
+++ b/rust/flake.nix
@@ -1,4 +1,3 @@
-# SPDX-FileCopyrightText: 2024-2025 Akira Komamura
 # SPDX-License-Identifier: Unlicense
 {
   inputs = {

--- a/treefmt/flake.nix
+++ b/treefmt/flake.nix
@@ -1,4 +1,3 @@
-# SPDX-FileCopyrightText: 2023-2025 Akira Komamura
 # SPDX-License-Identifier: Unlicense
 {
   inputs = {

--- a/treefmt/treefmt.nix
+++ b/treefmt/treefmt.nix
@@ -1,4 +1,3 @@
-# SPDX-FileCopyrightText: 2023-2025 Akira Komamura
 # SPDX-License-Identifier: Unlicense
 {
   projectRootFile = "treefmt.nix";

--- a/zig/.gitignore
+++ b/zig/.gitignore
@@ -1,4 +1,3 @@
-# SPDX-FileCopyrightText: 2024-2025 Akira Komamura
 # SPDX-License-Identifier: Unlicense
 
 # Zig

--- a/zig/flake.nix
+++ b/zig/flake.nix
@@ -1,4 +1,3 @@
-# SPDX-FileCopyrightText: 2024-2025 Akira Komamura
 # SPDX-License-Identifier: Unlicense
 {
   inputs = {

--- a/zig/treefmt.nix
+++ b/zig/treefmt.nix
@@ -1,4 +1,3 @@
-# SPDX-FileCopyrightText: 2024-2025 Akira Komamura
 # SPDX-License-Identifier: Unlicense
 {
   projectRootFile = "treefmt.nix";


### PR DESCRIPTION
Most files in the templates are unlicensed, which mean the materials are in the public domain. It is technically wrong to put a copyright statement in them, which I did by mistake. This PR removes them.