### PR TITLE
Improve the default CI setup

### DIFF
--- a/doc/src/content/docs/patterns/ci/github-actions.mdoc
+++ b/doc/src/content/docs/patterns/ci/github-actions.mdoc
@@ -13,10 +13,14 @@ process streamlines package distribution and installation.
 The workflow builds the default Nix package defined in your flake using the
 following third-party actions:
 
-- [install-nix-action](https://github.com/cachix/install-nix-action). There are
-  alternatives to this.
-- [Cachix](https://www.cachix.org/) via
-  [cachix-action](https://github.com/cachix/cachix-action) for Nix binary cache.
+- [nix-quick-install-action](https://github.com/nixbuild/nix-quick-install-action)
+  to install Nix.
+- [cache-nix-action](https://github.com/nix-community/cache-nix-action) to save
+  the Nix store to the GitHub Actions cache to reduce time spent on downloading
+  dependencies.
+- Optionally, you can enable
+  [cachix-action](https://github.com/cachix/cachix-action), so you can download
+  the artifacts built on CI to your machines as Nix binary cache.
 
 Note that there are some alternative hosted services for Nix CI. If the provided
 setup doesn't satisfy your requirements, you might consider the following
@@ -37,8 +41,70 @@ options:
 2. Adjust the `.github/workflows/nix-build.yml` file to match your project
    requirements.
 
-3. Get an authentication token on Cachix and save it as a secret variable
+3. Optionally, you can enable uploading to Cachix. Edit
+   `.github/actions/setup/action.yml` and uncomment relevant sections:
+
+   ```yaml
+   inputs:
+     cachix-name:
+       description: Name of the Cachix account
+       required: false
+       default: akirak
+     cachix-token:
+       description: Auth token for cachix
+       required: true
+   ```
+
+   ```yaml
+       - uses: cachix/cachix-action@v16
+         with:
+           name: ${{ inputs.cachix-name }}
+           authToken: '${{ inputs.cachix-token }}'
+   ```
+
+   Get an authentication token on Cachix and save it as a secret variable
    `CACHIX_AUTH_TOKEN` in your project.
+
+   In each workflow in `.github/workflows` directory, pass the auth token to the
+   action:
+
+   ```yaml
+         - name: Set up Nix
+           uses: ./.github/actions/setup
+           with:
+             cachix-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
+   ```
+
+4. To save more assets to the cache (e.g. packages of a language-native package
+   system), edit `.github/actions/setup/action.yml` and add their file paths to
+   `paths` option and tweak `primary-key` as needed:
+
+   ```yaml
+      - name: Restore the package cache
+        uses: nix-community/cache-nix-action@135667ec418502fa5a3598af6fb9eb733888ce6a # v6
+        with:
+          primary-key: nix-${{ runner.os }}-${{ hashFiles('**/flake.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-
+          gc-max-store-size-linux: 1G
+          paths: |
+            node_modules/.pnpm
+     ```
+
+5. To add more Nix-based workflows, just use the `./.github/actions/setup`
+   action:
+
+   ```yaml
+   jobs:
+     some-nix-job:
+       runs-on: ubuntu-latest
+       steps:
+         - uses: actions/checkout@v4
+
+         - name: Set up Nix
+           uses: ./.github/actions/setup
+           # with:
+           #   cachix-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
+   ```
 
 {% /steps %}
 

--- a/meta/.github/actions/setup/action.yml
+++ b/meta/.github/actions/setup/action.yml
@@ -1,0 +1,37 @@
+name: Set up Nix
+
+description: Set up Nix with a GH-native cache enabled
+
+# inputs:
+#   cachix-name:
+#     description: Name of the Cachix account
+#     required: false
+#     default: akirak
+#   cachix-token:
+#     description: Auth token for cachix
+#     required: true
+
+runs:
+  using: composite
+  steps:
+    - uses: nixbuild/nix-quick-install-action@5bb6a3b3abe66fd09bbf250dce8ada94f856a703 # v30
+      with:
+        nix_conf: |
+          keep-env-derivations = true
+          keep-outputs = true
+
+    - name: Restore the package cache
+      uses: nix-community/cache-nix-action@135667ec418502fa5a3598af6fb9eb733888ce6a # v6
+      with:
+        primary-key: nix-${{ runner.os }}-${{ hashFiles('**/flake.lock') }}
+        restore-prefixes-first-match: nix-${{ runner.os }}-
+        gc-max-store-size-linux: 1G
+        # Optionally, you can add extra paths saved to the cache.
+        #
+        # paths: |
+        #   node_modules/.pnpm
+
+    # - uses: cachix/cachix-action@v16
+    #   with:
+    #     name: ${{ inputs.cachix-name }}
+    #     authToken: '${{ inputs.cachix-token }}'

--- a/meta/.github/workflows/nix-build.yml
+++ b/meta/.github/workflows/nix-build.yml
@@ -32,15 +32,10 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
-      - uses: cachix/install-nix-action@526118121621777ccd86f79b04685a9319637641 # v31
-        with:
-          extra_nix_config: |
-            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
-
-      - uses: cachix/cachix-action@0fc020193b5a1fa3ac4575aa3a7d3aa6a35435ad # v16
-        with:
-          name: akirak
-          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+      - name: Set up Nix
+        uses: ./.github/actions/setup
+        # with:
+        #   cachix-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
       - name: Build the package
         run: nix build -L

--- a/meta/.github/workflows/nix-format.yml
+++ b/meta/.github/workflows/nix-format.yml
@@ -20,10 +20,10 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
-      - uses: cachix/install-nix-action@526118121621777ccd86f79b04685a9319637641 # v31
-        with:
-          extra_nix_config: |
-            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+      - name: Set up Nix
+        uses: ./.github/actions/setup
+        # with:
+        #   cachix-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
       - name: Check format
         run: |


### PR DESCRIPTION
1. Add a dedicated action to allow reusing the setup in multiple workflows
2. Use [nix-community/cache-nix-action](https://github.com/nix-community/cache-nix-action) to improve the CI performance
