### PR TITLE
fix: add missing -t flag

### DIFF
--- a/doc/src/content/docs/patterns/ci/github-actions.mdoc
+++ b/doc/src/content/docs/patterns/ci/github-actions.mdoc
@@ -35,7 +35,7 @@ options:
 1. Initialize the template from the root directory of the project:
 
    ```shell
-   nix flake init github:akirak/flake-templates#meta
+   nix flake init -t github:akirak/flake-templates#meta
    ```
 
 2. Adjust the `.github/workflows/nix-build.yml` file to match your project

--- a/doc/src/content/docs/patterns/formatting/treefmt-nix.mdoc
+++ b/doc/src/content/docs/patterns/formatting/treefmt-nix.mdoc
@@ -35,7 +35,7 @@ nix build ".#checks.$(nix eval --expr builtins.currentSystem --impure --raw).tre
 1. Initialize the template from the root directory of the project:
 
    ```shell
-   nix flake init github:akirak/flake-templates#meta
+   nix flake init -t github:akirak/flake-templates#meta
    ```
 
 2. Adjust the `.github/workflows/nix-format.yml` file to match your project

--- a/doc/src/content/docs/patterns/updating/renovate.mdoc
+++ b/doc/src/content/docs/patterns/updating/renovate.mdoc
@@ -12,7 +12,7 @@ The `meta` template contains an example configuration for Renovate.
 1. Initialize the template from the root directory of the project:
 
    ```shell
-   nix flake init github:akirak/flake-templates#meta
+   nix flake init -t github:akirak/flake-templates#meta
    ```
 
 2. Adjust the `.github/renovate.json` file to match your project

--- a/doc/src/content/docs/recipes/elixir/phoenix.mdoc
+++ b/doc/src/content/docs/recipes/elixir/phoenix.mdoc
@@ -58,7 +58,7 @@ to do this only once per machine:
 1. Initialize the template from the root directory of the project:
 
    ```shell
-   nix flake init github:akirak/flake-templates#elixir-app
+   nix flake init -t github:akirak/flake-templates#elixir-app
    ```
 
 2. Open `flake.nix` and set the Erlang and Elixir versions:

--- a/doc/src/content/docs/recipes/gleam/app.mdoc
+++ b/doc/src/content/docs/recipes/gleam/app.mdoc
@@ -44,7 +44,7 @@ If you are adding `flake.nix` to an existing project, you can skip this section.
 1. Initialize the template from the root directory of the project:
 
    ```shell
-   nix flake init github:akirak/flake-templates#gleam
+   nix flake init -t github:akirak/flake-templates#gleam
    ```
 
 2. Open `flake.nix` and update the Erlang version to the current one:

--- a/doc/src/content/docs/recipes/go/executable.mdoc
+++ b/doc/src/content/docs/recipes/go/executable.mdoc
@@ -24,7 +24,7 @@ complex project layout.
 1. Initialize the template from the root directory of the project:
 
    ```shell
-   nix flake init github:akirak/flake-templates#go
+   nix flake init -t github:akirak/flake-templates#go
    ```
 
 2. Add `.envrc`:

--- a/doc/src/content/docs/recipes/ocaml/basic.mdoc
+++ b/doc/src/content/docs/recipes/ocaml/basic.mdoc
@@ -29,7 +29,7 @@ with ocaml-dune template](/flake-templates/recipes/ocaml/generic-dune).
 1. Initialize the template from the root directory of the project:
 
    ```shell
-   nix flake init github:akirak/flake-templates#ocaml-basic
+   nix flake init -t github:akirak/flake-templates#ocaml-basic
    ```
 
    Open `flake.nix` and review the packages under the default development shell.

--- a/doc/src/content/docs/recipes/ocaml/generic-dune.mdoc
+++ b/doc/src/content/docs/recipes/ocaml/generic-dune.mdoc
@@ -52,7 +52,7 @@ If you are adding `flake.nix` to an existing project, you can skip this section.
 1. Initialize the template from the root directory of the project:
 
    ```shell
-   nix flake init github:akirak/flake-templates#ocaml-dune
+   nix flake init -t github:akirak/flake-templates#ocaml-dune
    ```
 
 2. Open `flake.nix` and set the `pname` and `version` of the package to be built, e.g.:

--- a/doc/src/content/docs/recipes/python/uv-basic.mdoc
+++ b/doc/src/content/docs/recipes/python/uv-basic.mdoc
@@ -80,7 +80,7 @@ projects. Below is just an example for this flake template.
 1. Initialize the template from the root directory of the project:
 
    ```shell
-   nix flake init github:akirak/flake-templates#python-uv-simple
+   nix flake init -t github:akirak/flake-templates#python-uv-simple
    ```
 
 2. Add `.envrc`:

--- a/doc/src/content/docs/recipes/rust/executable.mdoc
+++ b/doc/src/content/docs/recipes/rust/executable.mdoc
@@ -47,7 +47,7 @@ If you are adding `flake.nix` to an existing project, you can skip this section.
 1. Initialize the template from the root directory of the project:
 
    ```shell
-   nix flake init github:akirak/flake-templates#rust
+   nix flake init -t github:akirak/flake-templates#rust
    ```
 
    By default, the template will pick the **default** profile of the **latest**

--- a/doc/src/content/docs/recipes/typescript/web-framework.mdoc
+++ b/doc/src/content/docs/recipes/typescript/web-framework.mdoc
@@ -84,7 +84,7 @@ project. Below are some links:
 1. Initialize the template from the root directory of the project:
 
    ```shell
-   nix flake init github:akirak/flake-templates#node-typescript
+   nix flake init -t github:akirak/flake-templates#node-typescript
    ```
 
 2. If the `package.json` in the repository contains `packageManager` section,

--- a/doc/src/content/docs/recipes/zig/cli.mdoc
+++ b/doc/src/content/docs/recipes/zig/cli.mdoc
@@ -15,7 +15,7 @@ TODO
 1. Initialize the template from the root directory of the project:
 
    ```shell
-   nix flake init github:akirak/flake-templates#zig
+   nix flake init -t github:akirak/flake-templates#zig
    ```
 
 2. Add `.envrc`:


### PR DESCRIPTION
A couple of pages have the init command `nix flake init -t <repo>` without the `-t` flag.