### PR TITLE
Potential fix for code scanning alert no. 36: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/check-zig.yml
+++ b/.github/workflows/check-zig.yml
@@ -7,6 +7,8 @@ on:
       - .github/workflows/check-zig.yml
   workflow_dispatch:
   workflow_call:
+permissions:
+  contents: read
 concurrency:
   group: check-zig-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/akirak/flake-templates/security/code-scanning/36](https://github.com/akirak/flake-templates/security/code-scanning/36)

In general, to fix this category of problem, you explicitly define a `permissions` block either at the workflow root (applies to all jobs without their own permissions) or within the specific job, granting only the scopes needed. For a read-only CI job that just checks out code and runs tools, `contents: read` is typically sufficient.

For this workflow, the simplest, non-functional-change fix is to add a root-level `permissions` section with `contents: read`. None of the steps require write access to repository contents or other resources via GITHUB_TOKEN. Place the `permissions` block after the `on:` section and before `concurrency:` to keep with common conventions, but any root-level placement is valid. No imports or additional methods are needed; this is purely a YAML configuration change within `.github/workflows/check-zig.yml`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
