### PR TITLE
Potential fix for code scanning alert no. 35: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/akirak/flake-templates/security/code-scanning/35](https://github.com/akirak/flake-templates/security/code-scanning/35)

In general, this issue is fixed by adding an explicit `permissions` block to the workflow or to specific jobs, restricting the `GITHUB_TOKEN` to the minimal permissions required. For a simple lint/format check workflow that only checks out code and runs local tools, `contents: read` is typically sufficient.

For this specific workflow in `.github/workflows/lint.yml`, the best fix with no functional changes is to add a workflow-level `permissions` section after the `on:` block, setting `contents: read`. This will apply to all jobs (currently only `lint`) that do not override permissions, and still allow `actions/checkout` to read repository contents. No other scopes (like `pull-requests`, `issues`, or write access) appear necessary based on the shown steps.

Concretely:
- Edit `.github/workflows/lint.yml`.
- After line 5 (`workflow_dispatch:`) and the blank line, insert:

```yaml
permissions:
  contents: read
```

- Keep the rest of the file unchanged. No imports or additional definitions are required since this is YAML configuration only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
