### PR TITLE
Potential fix for code scanning alert no. 33: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/check-treefmt.yml
+++ b/.github/workflows/check-treefmt.yml
@@ -9,6 +9,9 @@ on:
   workflow_dispatch:
   workflow_call:
 
+permissions:
+  contents: read
+
 concurrency:
   group: check-treefmt-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/akirak/flake-templates/security/code-scanning/33](https://github.com/akirak/flake-templates/security/code-scanning/33)

In general, the fix is to explicitly define a `permissions` block with the least privileges needed, either at the workflow root (applies to all jobs) or inside the specific job. This workflow only checks out code and uses the token to read from GitHub; it does not perform any writes (no pushes, no issue/PR updates). Therefore the minimal appropriate permission is `contents: read`. Adding this at the top level ensures all current and future jobs in this workflow inherit restricted permissions unless they override them.

Concretely, in `.github/workflows/check-treefmt.yml`, add a `permissions:` section near the top (for example after `on:` or after `concurrency:` is also fine, but placing it with other workflow-level config is clearer). The block should specify `contents: read`. No additional imports or methods are needed; this is purely a YAML configuration change. Existing functionality remains unchanged because all used actions (`actions/checkout` and `cachix/install-nix-action` with `GITHUB_TOKEN` only for reading) are compatible with read-only contents permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
