### PR TITLE
Potential fix for code scanning alert no. 25: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/check-minimal.yml
+++ b/.github/workflows/check-minimal.yml
@@ -9,6 +9,9 @@ on:
   workflow_dispatch:
   workflow_call:
 
+permissions:
+  contents: read
+
 concurrency:
   group: check-minimal-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/akirak/flake-templates/security/code-scanning/25](https://github.com/akirak/flake-templates/security/code-scanning/25)

To fix the problem, add an explicit `permissions` block so that the `GITHUB_TOKEN` is restricted to the minimal scopes required. This can be done at the workflow root (applies to all jobs) or within the `check` job. Given there is only one job, either is fine; adding it at the top level documents the default for any future jobs in this workflow.

The job only needs to read repository contents (for checkout and any GitHub‑hosted resources Nix may fetch), so `contents: read` is an appropriate minimal permission. No write scopes are needed since there are no steps that modify GitHub resources (issues, PRs, etc.).

Concretely:
- Edit `.github/workflows/check-minimal.yml`.
- Insert a `permissions:` block with `contents: read` after the `on:` block (e.g., after line 10/11) so it applies to all jobs.
- No additional imports, methods, or definitions are required; this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
