### PR TITLE
Potential fix for code scanning alert no. 23: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/check-go.yml
+++ b/.github/workflows/check-go.yml
@@ -7,6 +7,8 @@ on:
       - .github/workflows/check-go.yml
   workflow_dispatch:
   workflow_call:
+permissions:
+  contents: read
 concurrency:
   group: check-go-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/akirak/flake-templates/security/code-scanning/23](https://github.com/akirak/flake-templates/security/code-scanning/23)

In general, the fix is to explicitly declare a `permissions` block in the workflow, either at the top level (affecting all jobs) or per job, and restrict the GITHUB_TOKEN to the minimal necessary scopes. For a read-only CI/check workflow like this, `contents: read` is typically sufficient.

The best minimal, non-functional-change fix here is to add a top-level `permissions` block just under the workflow `name:` or `on:` section in `.github/workflows/check-go.yml`, setting `contents: read`. This will apply to all jobs in the workflow (currently only `check`) and ensure the GITHUB_TOKEN cannot perform write operations to the repository while keeping all current steps functional. No imports or additional methods are needed because this is a YAML configuration change only.

Concretely: in `.github/workflows/check-go.yml`, insert:

```yaml
permissions:
  contents: read
```

between the `on:` block and the `concurrency:` block (or right after `name:`; either is fine syntactically), keeping indentation consistent (no leading spaces, as it’s a top-level key).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
