### PR TITLE
Potential fix for code scanning alert no. 22: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/check-flake-utils.yml
+++ b/.github/workflows/check-flake-utils.yml
@@ -9,6 +9,9 @@ on:
   workflow_dispatch:
   workflow_call:
 
+permissions:
+  contents: read
+
 concurrency:
   group: check-flake-utils-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/akirak/flake-templates/security/code-scanning/22](https://github.com/akirak/flake-templates/security/code-scanning/22)

In general, the fix is to add an explicit `permissions` block to the workflow or to the specific job so that the GITHUB_TOKEN has only the minimal required scopes. For this workflow, the job only needs to read the repository contents to run Nix and build the flake; it does not need to write to the repository or to issues/PRs. Thus, `contents: read` is an appropriate minimal configuration.

The best fix without changing behavior is to add a root-level `permissions` block (applies to all jobs) just after the `on:` section and before `concurrency:`. This will set `contents: read` for the entire workflow, satisfying CodeQL’s recommendation and enforcing least privilege. No imports or other definitions are needed; this is purely a YAML configuration change in `.github/workflows/check-flake-utils.yml`.

Specifically:
- Edit `.github/workflows/check-flake-utils.yml`.
- After line 10 (`workflow_call:`) and the following blank line, insert:

```yaml
permissions:
  contents: read
```

This ensures the `check` job (and any future jobs without their own `permissions` block) use a read-only token for repository contents.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
