### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/check-elixir.yml
+++ b/.github/workflows/check-elixir.yml
@@ -9,6 +9,9 @@ on:
   workflow_dispatch:
   workflow_call:
 
+permissions:
+  contents: read
+
 concurrency:
   group: check-elixir-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/akirak/flake-templates/security/code-scanning/7](https://github.com/akirak/flake-templates/security/code-scanning/7)

To fix the problem, explicitly define `permissions` in the workflow so that the `GITHUB_TOKEN` is limited to the least privilege required. This workflow only needs to read repository contents (for `actions/checkout` and Nix flake/template operations), so `contents: read` is sufficient and aligns with the minimal starting point suggested by CodeQL.

The best way to fix this without changing existing functionality is to add a root-level `permissions` block near the top of `.github/workflows/check-elixir.yml`, so it applies to all jobs (the single `check` job) unless overridden. Place it after the `on:` block and before `concurrency:` to keep the YAML organized and clear. The block should look like:

```yaml
permissions:
  contents: read
```

No additional methods, imports, or dependencies are required; this is purely a configuration change in the workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
