### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-and-publish-doc.yml
+++ b/.github/workflows/build-and-publish-doc.yml
@@ -17,6 +17,8 @@ concurrency:
 
 jobs:
   build-and-upload:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6


### PR DESCRIPTION
Potential fix for [https://github.com/akirak/flake-templates/security/code-scanning/6](https://github.com/akirak/flake-templates/security/code-scanning/6)

In general, to fix this issue you should explicitly specify the GITHUB_TOKEN permissions for each job (or at the workflow root) so they are limited to what the job actually needs. This avoids inheriting potentially broad repository defaults and documents the workflow’s security requirements.

The best minimal change here is to add a `permissions` block for the `build-and-upload` job, since `deploy` already has one. This job only needs to read the repository contents (for checkout) and upload an artifact; none of its steps write to the repository or interact with issues/PRs, so `contents: read` is sufficient. We do not need any new imports or dependencies; this is purely a YAML configuration change.

Concretely, in `.github/workflows/build-and-publish-doc.yml`, under `jobs:`, within the `build-and-upload` job and before `runs-on: ubuntu-latest`, add:

```yaml
permissions:
  contents: read
```

No other lines or files need to be modified.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
