### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/check-elixir-app.yml
+++ b/.github/workflows/check-elixir-app.yml
@@ -1,5 +1,8 @@
 name: Check elixir-app
 
+permissions:
+  contents: read
+
 on:
   push:
     paths:


### PR DESCRIPTION
Potential fix for [https://github.com/akirak/flake-templates/security/code-scanning/5](https://github.com/akirak/flake-templates/security/code-scanning/5)

In general, to fix this kind of issue you explicitly set a `permissions` block either at the top level of the workflow (applying to all jobs by default) or within the specific job. You assign only the scopes actually needed (often `contents: read` is sufficient for simple CI jobs that just check out and build/test code).

For this workflow, the single best fix is to add a top-level `permissions` block right after the `name:` (before `on:`) that sets `contents: read`. None of the steps use GitHub API operations requiring write permissions (no issue/PR updates, no releases, etc.), and the only interaction with GitHub is via `actions/checkout` and Nix using the `GITHUB_TOKEN` as an access token to read contents. Therefore `contents: read` is sufficient and implements least privilege without changing observable functionality.

The change is confined to `.github/workflows/check-elixir-app.yml`. No additional imports or methods are needed; it is just a YAML configuration edit. We will insert:

```yaml
permissions:
  contents: read
```

near the top of the file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
