### PR TITLE
Potential fix for code scanning alert no. 24: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/check-gleam.yml
+++ b/.github/workflows/check-gleam.yml
@@ -9,6 +9,9 @@ on:
   workflow_dispatch:
   workflow_call:
 
+permissions:
+  contents: read
+
 concurrency:
   group: check-gleam-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/akirak/flake-templates/security/code-scanning/24](https://github.com/akirak/flake-templates/security/code-scanning/24)

In general, the fix is to explicitly declare a `permissions` block that grants only the minimal required access to `GITHUB_TOKEN`. Since this workflow only checks out code and runs local commands, it only needs read access to repository contents. The safest standard baseline is `contents: read`.

The best way to fix this specific workflow without changing its behavior is to add a `permissions` block at the workflow root (top level, alongside `on:` and `concurrency:`). This will apply to all jobs in the workflow that do not override permissions. Concretely, in `.github/workflows/check-gleam.yml`, insert:

```yaml
permissions:
  contents: read
```

between the `on:` block (ending at line 10) and the `concurrency:` block (starting at line 12). No additional imports, methods, or definitions are needed since this is a pure YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
