### PR TITLE
Potential fix for code scanning alert no. 31: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/check-python-uv-simple.yml
+++ b/.github/workflows/check-python-uv-simple.yml
@@ -9,6 +9,9 @@ on:
   workflow_dispatch:
   workflow_call:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/akirak/flake-templates/security/code-scanning/31](https://github.com/akirak/flake-templates/security/code-scanning/31)

To fix the problem, explicitly declare restrictive `permissions` in the workflow so the `GITHUB_TOKEN` is limited to the minimal rights needed. This workflow only checks out code and runs Nix/commands locally, so it only needs read access to repository contents (and possibly packages if private packages are involved, but nothing in the snippet indicates that).

The best, least-invasive change is to add a top-level `permissions` block that applies to all jobs. Place it after the `on:` section (or before `concurrency:`) in `.github/workflows/check-python-uv-simple.yml`, with `contents: read`. This documents required permissions and prevents accidental elevation if org/repo defaults are changed or if this file is copied elsewhere. No additional imports or methods are required; it’s purely a YAML configuration change within the shown file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
