### PR TITLE
Potential fix for code scanning alert no. 38: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -5,6 +5,9 @@ on:
     - cron: '0 4 * * 5'
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/akirak/flake-templates/security/code-scanning/38](https://github.com/akirak/flake-templates/security/code-scanning/38)

In general, the fix is to add an explicit `permissions` block to the workflow (at the top level so it applies to all jobs) or to the specific `update` job, granting only the minimal scopes required. This documents the intended privileges and prevents the job from inheriting broader repository or organization defaults.

For this particular workflow, the steps interact with the repository contents via `git` and rely on `peter-evans/create-pull-request`, which requires write access to commit and push branches and open pull requests. The action’s documentation indicates that `contents: write` is required; in some configurations `pull-requests: write` is also used, but that is typically via `GITHUB_TOKEN`. Since the PR here is authenticated with `secrets.PAT_FOR_PR`, the `GITHUB_TOKEN` primarily needs to read and possibly write contents for the earlier Git operations. To be safe and still minimal, we can set `permissions` at workflow root to:

```yaml
permissions:
  contents: write
```

This keeps the token limited to repository contents and avoids generic write access to other areas (issues, actions, etc.). Concretely, edit `.github/workflows/update.yml` to insert a `permissions` block between the `on:` section and the `concurrency:` section (e.g., after line 6). No additional imports, methods, or other definitions are required; this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
