### PR TITLE
Potential fix for code scanning alert no. 34: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -1,5 +1,8 @@
 name: Check license
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     # This ignore list does not cover the entire set of irrelevant files, but it


### PR DESCRIPTION
Potential fix for [https://github.com/akirak/flake-templates/security/code-scanning/34](https://github.com/akirak/flake-templates/security/code-scanning/34)

In general, the fix is to explicitly define a `permissions` block that grants only the minimal rights needed. This can be set at the workflow root (applies to all jobs without their own `permissions`) or per job. Since this workflow only needs to read repository contents, `contents: read` is sufficient.

The best fix here, without changing functionality, is to add a `permissions` block at the root level of `.github/workflows/license.yml`, just after the `name:` line (or before `jobs:`). This block should limit the `GITHUB_TOKEN` to read‑only access to repository contents:

```yaml
permissions:
  contents: read
```

No additional imports or methods are needed; this is purely a YAML configuration change in `.github/workflows/license.yml`. No existing steps or behavior need to be modified.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
