### PR TITLE
Potential fix for code scanning alert no. 32: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/check-rust.yml
+++ b/.github/workflows/check-rust.yml
@@ -9,6 +9,9 @@ on:
   workflow_dispatch:
   workflow_call:
 
+permissions:
+  contents: read
+
 concurrency:
   group: check-rust-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/akirak/flake-templates/security/code-scanning/32](https://github.com/akirak/flake-templates/security/code-scanning/32)

To fix the problem, add an explicit `permissions` block that scopes the `GITHUB_TOKEN` to the least privileges needed. This workflow only needs to read repository contents (for `actions/checkout` and Nix flake use); it does not need to write to the repo or interact with issues/PRs. Therefore, `contents: read` at the workflow or job level is sufficient.

The best fix without changing functionality is to add a `permissions` section at the top workflow level (so it applies to all jobs) right after the `on:` block and before `concurrency:`. Concretely, in `.github/workflows/check-rust.yml`, insert:

```yaml
permissions:
  contents: read
```

properly indented at the root of the YAML. No imports or additional methods are required; this is purely a configuration change within the workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
