### PR TITLE
Potential fix for code scanning alert no. 30: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/check-ocaml-dune.yml
+++ b/.github/workflows/check-ocaml-dune.yml
@@ -16,6 +16,8 @@ concurrency:
 jobs:
   check:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: cachix/install-nix-action@4e002c8ec80594ecd40e759629461e26c8abed15 # v31
         with:


### PR DESCRIPTION
Potential fix for [https://github.com/akirak/flake-templates/security/code-scanning/30](https://github.com/akirak/flake-templates/security/code-scanning/30)

In general, the fix is to explicitly declare a `permissions:` block either at the top level of the workflow (to apply to all jobs) or within the `check` job, setting the least privileges needed—here, read access to repository contents should be sufficient.

The best minimal fix without changing functionality is to add a job-level `permissions:` block under `jobs.check`, parallel to `runs-on`. The job only needs to read the repository via `actions/checkout` and to use the token as an access token for Nix; no GitHub writes are performed. Thus we can set `permissions: contents: read`. This directly addresses CodeQL’s suggestion and keeps the token from having broader default scopes.

Concretely, in `.github/workflows/check-ocaml-dune.yml`, under `jobs: check:`, insert:

```yaml
    permissions:
      contents: read
```

between `runs-on: ubuntu-latest` and `steps:` (or before `runs-on`, order doesn’t matter semantically, but we’ll place it immediately after `runs-on` for clarity). No imports or additional definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
