### PR TITLE
Potential fix for code scanning alert no. 29: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/check-pre-commit.yml
+++ b/.github/workflows/check-pre-commit.yml
@@ -9,6 +9,9 @@ on:
   workflow_dispatch:
   workflow_call:
 
+permissions:
+  contents: read
+
 concurrency:
   group: check-pre-commit-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/akirak/flake-templates/security/code-scanning/29](https://github.com/akirak/flake-templates/security/code-scanning/29)

In general, the fix is to add an explicit `permissions` block that grants only the scopes required by this workflow. Since this job just checks a pre-commit template, needs to read the repository contents, and does not interact with issues or pull requests, the least-privilege setting is `contents: read`. We can set this at the workflow level so it applies to all jobs (there is only one job, `check`).

The best single change is to insert a workflow-level `permissions` block after the `on:` section and before `concurrency:`. This will restrict the `GITHUB_TOKEN` for all jobs in this workflow to read-only access to repository contents, without changing any of the existing job steps or behavior. No imports or additional methods are needed, as this is a pure YAML configuration change within `.github/workflows/check-pre-commit.yml`.

Concretely:
- Edit `.github/workflows/check-pre-commit.yml`.
- After line 10 (`workflow_call:`) and the blank line at 11, insert:

```yaml
permissions:
  contents: read
```

- Keep indentation consistent with other top-level keys (`on`, `concurrency`, `jobs`).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
