### PR TITLE
Potential fix for code scanning alert no. 28: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/check-ocaml-basic.yml
+++ b/.github/workflows/check-ocaml-basic.yml
@@ -9,6 +9,9 @@ on:
   workflow_dispatch:
   workflow_call:
 
+permissions:
+  contents: read
+
 concurrency:
   group: check-ocaml-basic-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/akirak/flake-templates/security/code-scanning/28](https://github.com/akirak/flake-templates/security/code-scanning/28)

In general, the fix is to add an explicit `permissions:` block to the workflow or to the specific job so that the GITHUB_TOKEN is limited to only the scopes needed. For a read-only CI workflow that just checks out code and runs tools, `permissions: contents: read` at the workflow root is usually sufficient and matches CodeQL’s suggested minimal configuration.

For this specific workflow in `.github/workflows/check-ocaml-basic.yml`, the best minimal change is to add a root-level `permissions:` block after the `on:` section (before `concurrency:`). This block should set `contents: read`, which allows the job to check out the repository and read its contents without granting any write permissions. No other scopes appear necessary from the provided steps; they primarily use Nix and local commands, and the third-party actions shown do not require write access to GitHub resources. No additional imports or dependencies are needed; we only modify the YAML.

Concretely:
- Edit `.github/workflows/check-ocaml-basic.yml`.
- Insert:

  ```yaml
  permissions:
    contents: read
  ```

  between the `on:` block (ending at line 10) and the existing `concurrency:` block (currently at line 12).
- Leave the rest of the workflow unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
