### PR TITLE
Potential fix for code scanning alert no. 26: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/check-java.yml
+++ b/.github/workflows/check-java.yml
@@ -9,6 +9,9 @@ on:
   workflow_dispatch:
   workflow_call:
 
+permissions:
+  contents: read
+
 concurrency:
   group: check-java-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/akirak/flake-templates/security/code-scanning/26](https://github.com/akirak/flake-templates/security/code-scanning/26)

In general, you fix this problem by explicitly defining a `permissions` block either at the top (workflow-wide) level or for the specific job, granting only the scopes that the workflow actually needs. For simple build/check workflows that only need to read repository contents, `contents: read` is typically sufficient.

For this workflow, no step requires write access to the repository, issues, or pull requests. Therefore the single best minimal fix is to add a workflow-wide `permissions` block near the top of `.github/workflows/check-java.yml`, setting `contents: read`. This will apply to the `check` job (and any future jobs unless they override it) and restrict the `GITHUB_TOKEN` while preserving current behavior. No additional imports or dependencies are needed.

Concretely, insert:

```yaml
permissions:
  contents: read
```

after the `on:` block and before `concurrency:` (or equivalently at the top-level anywhere before `jobs:`). No existing lines need to be modified; we just add these new lines.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
