### PR TITLE
Potential fix for code scanning alert no. 21: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/check-flake-parts.yml
+++ b/.github/workflows/check-flake-parts.yml
@@ -16,6 +16,8 @@ concurrency:
 jobs:
   check:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
     - uses: cachix/install-nix-action@4e002c8ec80594ecd40e759629461e26c8abed15 # v31
       with:


### PR DESCRIPTION
Potential fix for [https://github.com/akirak/flake-templates/security/code-scanning/21](https://github.com/akirak/flake-templates/security/code-scanning/21)

In general, the fix is to explicitly define a `permissions` block that grants only the minimal scopes needed by the workflow or job. Since this job only needs to read repository contents (for checkout and Nix operations) and does not appear to write to the repo, issues, or PRs, we can set `contents: read`. We can do this either at the workflow root (applies to all jobs) or inside the `check` job. To keep the change minimal and scoped, we’ll add the `permissions` block to the `check` job.

Concretely, in `.github/workflows/check-flake-parts.yml`, under `jobs:  check:`, add:

```yaml
    permissions:
      contents: read
```

indented to align with `runs-on`. No additional imports or methods are required, as this is pure workflow configuration. No existing functionality changes: `actions/checkout` works with `contents: read`, and the Nix commands and local `git` operations do not require write access to the GitHub API.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
