### PR TITLE
Potential fix for code scanning alert no. 37: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/check-typescript-effect.yml
+++ b/.github/workflows/check-typescript-effect.yml
@@ -14,6 +14,8 @@ concurrency:
 
 jobs:
   check:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
     - uses: cachix/install-nix-action@4e002c8ec80594ecd40e759629461e26c8abed15 # v31


### PR DESCRIPTION
Potential fix for [https://github.com/akirak/flake-templates/security/code-scanning/37](https://github.com/akirak/flake-templates/security/code-scanning/37)

In general, the fix is to add an explicit `permissions` block that restricts `GITHUB_TOKEN` to the minimal required scope. Since this workflow only needs to read repository contents via `actions/checkout` and to authenticate to GitHub for Nix flake access, `contents: read` is sufficient. We can apply this either at the workflow root (affecting all jobs) or at the `check` job level. To keep the change minimal and aligned with the CodeQL warning on the job, we will add `permissions: contents: read` under the `check` job.

Concretely: in `.github/workflows/check-typescript-effect.yml`, locate the `jobs:` section and the `check:` job where `runs-on: ubuntu-latest` is defined (around line 16–18). Insert a `permissions:` mapping between `check:` and `runs-on: ubuntu-latest`, indented to match YAML structure:

```yaml
jobs:
  check:
    permissions:
      contents: read
    runs-on: ubuntu-latest
    steps:
      ...
```

No imports or additional methods are needed; it is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
